### PR TITLE
Fixes typo

### DIFF
--- a/testgranularity/unittesting.ipynb
+++ b/testgranularity/unittesting.ipynb
@@ -151,7 +151,7 @@
         "id": "MCbp_TrQ0BKc"
       },
       "source": [
-        "We created 4 unit tests, each test is checking a method of the Calculator class, this check is being done through the call to an `Asection`, in this case the `assertEqual` function."
+        "We created 4 unit tests, each test is checking a method of the Calculator class. These checks are being done through calls to `Assertions`, in this case the `assertEqual` function."
       ]
     },
     {


### PR DESCRIPTION
Fixes `Asection` typo, changing it to `Assertions`. I also changed a bit the plural agreement of the phrase.