### PR TITLE
Fixing ACTS demo code 

### DIFF
--- a/demos/5-cit-acts/test.py
+++ b/demos/5-cit-acts/test.py
@@ -10,15 +10,16 @@ def parse_config(filename):
         for line in lines:
             line = line.strip()
             if not line: # Empty line
+                if config:
+                    configs.append(config)
+                    config = {}
                 continue
             if line.startswith("#"): # Comment
                 continue
             elif line.startswith("-----"): # Configuration separator
                 continue
             elif line.startswith("Configuration"):
-                if config:
-                    configs.append(config)
-                config = {}
+                continue
             else: # Configuration parameter with its value
                 parts = line.split()
                 keyval = parts[2]


### PR DESCRIPTION
On test.py, including the configuration only when a new line started with "Configuration" made it miss the last configuration from the output.txt file. 

https://github.com/leopoldomt/practical_testing_book/blob/3372bf612040ff087f3ba2d0de650ceee7196c5a/demos/5-cit-acts/test.py#L18-L21

